### PR TITLE
Escape forward slash in regex

### DIFF
--- a/src/Terminal/commands/expr.ts
+++ b/src/Terminal/commands/expr.ts
@@ -17,7 +17,7 @@ export function expr(
   const expr = args.join("");
 
   // Sanitize the math expression
-  const sanitizedExpr = expr.replace(/s+/g, "").replace(/[^-()\d/*+.%]/g, "");
+  const sanitizedExpr = expr.replace(/s+/g, "").replace(/[^-()\d\/*+.%]/g, "");
   let result;
   try {
     result = eval(sanitizedExpr);


### PR DESCRIPTION
All documentation and regex testers I have found state that forward slashes ("/") inside regex patterns should be escaped, since the forward slash is used to define the start and end of the pattern.
The ECMA standard only states that it "shall be escaped as necessary" for it to parse correctly, but I think the better practice is to always escape it.
https://262.ecma-international.org/12.0/#sec-escaperegexppattern
Other posts I have seen about it say it has to be escaped when in the /pattern/ notation but not in the RegExp constructor.